### PR TITLE
added support for use in modules

### DIFF
--- a/R/shinyFilters.R
+++ b/R/shinyFilters.R
@@ -1,9 +1,10 @@
-
+setClassUnion("nullOrchar", c("NULL", "character"))
 setClass('filterSet',
          representation(id = 'character',
                         filterList = 'list',
                         output = 'data.frame',
-                        filterUINames = 'character')
+                        filterUINames = 'character',
+                        moduleID = 'nullOrchar')
          # prototype=c(fundInfo=NA,cashflow=NA,FX=NA)
 )
 
@@ -15,8 +16,8 @@ setClass('filterSet',
 #' @export
 #'
 #' @examples
-newFilterSet <- function(id='myFilters'){
-  new('filterSet',id=id,filterList=list(),filterUINames = c('GF-filterMaster'))#)list(filterResetModule(id)))
+newFilterSet <- function(id='myFilters', moduleID=NULL){
+  new('filterSet',id=id,filterList=list(),filterUINames = c('GF-filterMaster'), moduleID=moduleID)#)list(filterResetModule(id)))
 }
 
 #' filterInput
@@ -32,7 +33,12 @@ newFilterSet <- function(id='myFilters'){
 #' @examples
 filterInput <- function(set, filterid, label=NULL, ...){
   filter <- set@filterList[[filterid]]
-  ns <- NS(set@id)
+  # Add module namespace if moduleID is not NULL
+  if(!is.null(set@moduleID)){
+    ns <- shiny::NS(paste(set@moduleID,set@id, sep = "-"))
+  } else {
+    ns <- shiny::NS(set@id)
+  }
   if(is.null(label)) label <- filterid
   filter$UI(id = ns(filterid),label=label,...)
 
@@ -117,8 +123,12 @@ filterSliderCustomInput <- function(id,label,value){
 #'
 #' @examples
 filterResetButton <- function(set,label='Reset Filters',...){
-  id <- set@id
-  ns <- NS(id)
+  # Add module namespace if moduleID is not NULL
+  if(!is.null(set@moduleID)){
+    ns <- shiny::NS(paste(set@moduleID,set@id, sep = "-"))
+  } else {
+    ns <- shiny::NS(set@id)
+  }
   actionButton(ns('resetFilter'),label,...)
 }
 
@@ -148,8 +158,12 @@ filterInputs <- function(set){
 #'
 #' @examples
 filterMaster <- function(set,label='Active Filters',choices='',...){
-  id <- set@id
-  ns <- NS(id)
+  # Add module namespace if moduleID is not NULL
+  if(!is.null(set@moduleID)){
+    ns <- shiny::NS(paste(set@moduleID,set@id, sep = "-"))
+  } else {
+    ns <- shiny::NS(set@id)
+  }
   selectizeInput(ns('filterMaster'),label = label,choices,multiple=T,...)
 }
 

--- a/examples/example-moduleUse.R
+++ b/examples/example-moduleUse.R
@@ -1,0 +1,56 @@
+if(interactive()) {
+
+  library(shiny)
+  library(shinyjs)
+  library(dplyr)
+  library(shinyFilters)
+
+  # create filterset in global section of app
+  filterSet <- newFilterSet('FS1', moduleID = "mod_name") %>%
+    # give each filter unique id and tell it which column to filter on
+    addSelectFilter('cylinders','cyl') %>%
+    addSelectFilter('gears','gear') %>%
+    addSliderFilter('disp',value=c(0,500)) %>%
+    addSelectFilter('carb') %>%
+    addCustomSliderFilter('hp',value=seq(0,500,50))
+
+  ModuleUI <- function(id) {
+    ns <- shiny::NS(id)
+
+    shiny::fluidPage(
+      #shinyjs is required to show/hide filters
+      shinyjs::useShinyjs(),
+      shiny::sidebarLayout(
+        shiny::sidebarPanel(
+          filterInputs(filterSet),
+          shiny::hr(),
+          filterMaster(filterSet),
+          filterResetButton(filterSet)
+        ),
+        shiny::mainPanel(
+          DT::dataTableOutput(ns("data"))
+        )
+      ))
+  }
+
+
+  ModuleServer <- function(input, output, session, data_f = data_mut, filterSet) {
+    # wrap data in reactive expression in case you
+    # need to do something to the data before filtering
+    data <- shiny::reactive(mtcars)
+
+    # initialize the filter set
+    filterSet <- initializeFilterSet(filterSet, data)
+
+    # the output is a reactive data.frame
+    output$data <- DT::renderDataTable(filterSet$output())
+
+  }
+
+
+  ui <- shiny::shinyUI(ModuleUI("mod_name"))
+
+  server <- function(input, output, session) {shiny::callModule(ModuleServer, "mod_name", filterSet = filterSet)}
+
+  shiny::shinyApp(ui, server)
+}


### PR DESCRIPTION
`newFilterSet()` now takes an argument `modueID` allowing users to explicitly set the name of the module their filtering will be used in. If moduleID is not NULL (default is NULL). the `ns` in `filterInput`, `filterMaster` and `filterResetButton` are amended to include the additional namespace of the module at the top level. 

Tested with example script in folder `examples`. 

This merge closes #6 